### PR TITLE
Fix #3: suppress HuggingFace verbose load warnings

### DIFF
--- a/BERT-for-sentiment-analysis.ipynb
+++ b/BERT-for-sentiment-analysis.ipynb
@@ -28,6 +28,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "source": [
+    "# Suppress Hugging Face verbose load warnings\n",
+    "from transformers import logging as hf_logging\n",
+    "hf_logging.set_verbosity_error()"
+   ],
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  },
+  {
    "cell_type": "markdown",
    "source": [
     "**Load Libraries**"


### PR DESCRIPTION
## What does this PR do?
Adds `hf_logging.set_verbosity_error()` at the top of the notebook to suppress the noisy UNEXPECTED key warnings printed when loading bert-base-uncased.

## Why?
These warnings are harmless but clutter the notebook output. Suppressing them improves readability without affecting model behavior.

## Testing
- Re-ran all notebook cells — training and evaluation results unchanged
- No UNEXPECTED key messages appear in output

Closes #3